### PR TITLE
update ogp image

### DIFF
--- a/HiCoder-site/index.html
+++ b/HiCoder-site/index.html
@@ -14,7 +14,7 @@
     <meta property="og:description"
         content="HiCoderは、広島大学のコンピュータ好きの学生たちが集まるサークルです。Web制作やアプリ開発、競技プログラミングなど、さまざまな活動に積極的に取り組んでいます。">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="assets/img/ogp.png">
+    <meta property="og:image" content="https://hicoder.one/assets/img/ogp.png">
     <title>HiCoder｜広島大学コンピュータサークル</title>
     <link rel="icon" href="assets/img/logo-1.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## OGP画像のリンク修正

### 変更点
- `og:image` のパスを `assets/img/ogp.png` から `https://hicoder.one/assets/img/ogp.png` に変更