### PR TITLE
ci: Dependabot 自動マージ（ビルド成功を条件に）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # npm / pnpm dependencies
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      # Bundle non-major updates into a single PR to reduce noise
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions used in .github/workflows
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.2.2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

Dependabot のセキュリティ/バージョン更新を、**ビルド成功を条件に自動マージ**するための設定を追加します。

## 変更内容

| ファイル | 役割 |
|---|---|
| `.github/dependabot.yml` | npm/pnpm と github-actions の更新を毎週チェック。minor/patch をグルーピングして PR 乱立を抑制 |
| `.github/workflows/ci.yml` | 全 PR でビルド実行（ジョブ名 `build` を必須チェックにする） |
| `.github/workflows/dependabot-auto-merge.yml` | patch/minor 更新を build 成功後に自動マージ。major は手動レビュー対象 |

- `dependabot/fetch-metadata` はサプライチェーン対策として SHA 固定（v2.5.0）。
- 自動マージは `gh pr merge --auto --squash`。branch protection の必須チェック `build` がグリーンになり次第マージされ、失敗時は保留。

## マージ後に必要な手動設定

1. **Settings → General → Allow auto-merge** を ON
2. **Settings → Actions → General → Workflow permissions**
   - Read and write permissions
   - Allow GitHub Actions to create and approve pull requests
3. **Settings → Branches → main** に branch protection rule を追加
   - Require status checks to pass before merging → `build` を必須チェックに追加
   - レビュー承認は不要（承認数 0）

## 動作フロー

```
Dependabot PR → ci.yml の build 実行
  → patch/minor なら auto-merge 発行
  → build グリーンで自動マージ／失敗なら保留
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)